### PR TITLE
Clean up Data Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .mypy_cache/
 project-folder/.mypy_cache
 .env
+*.csv

--- a/project-folder/data.py
+++ b/project-folder/data.py
@@ -1,17 +1,56 @@
-#!bin/bash/env python3
-
 import os
-import zipfile
-import pandas as pd
-import numpy as np
+import sys
 import kaggle
+import pandas as pd
 
-from typing import Optional
-from kaggle.api.kaggle_api_extended import KaggleApi
+from dotenv import load_dotenv
 
-data_path = os.path.join(os.getcwd(), 'data')
 
-print(data_path)
+class DataPipeline:
+    def __init__(self):
+        # List of preprocessing steps
+        # Applied in the order they appear
+        self.preprocessing_steps = [
+                                        self.placeholder_callable_1,
+                                        self.placeholder_callable_2,
+                                    ]
+        self.data_path = os.path.join(os.getcwd(), 'data')
+        self.skin_data: pd.DataFrame
 
-kaggle.api.authenticate()
-kaggle.api.dataset_download_files('kmader/skin-cancer-mnist-ham10000', path=data_path, unzip = True)
+        # Loading environment variables
+        dotenv_path = os.path.dirname(os.getcwd())
+        load_dotenv(dotenv_path + '/.env')
+
+    '''
+        Preprocessing steps used to clean/feature engineer the data
+        Example: normalization
+    '''
+
+    def placeholder_callable_1(self, row):
+        return row
+
+    def placeholder_callable_2(self, row):
+        return row
+
+    '''
+        End preprocessing steps
+    '''
+
+    def download_files_from_kaggle(self):
+        if not os.path.isfile('data/hmnist_28_28_RGB.csv'):
+            try:
+                kaggle.api.authenticate()
+                kaggle.api.dataset_download_files('kmader/skin-cancer-mnist-ham10000',  # noqa
+                                            path=self.data_path, unzip=True)
+            except TimeoutError:
+                print('TimeoutError: manually download and try again')
+                sys.exit()
+        self.skin_data = pd.read_csv('data/hmnist_28_28_RGB.csv')
+
+    # This will be the entry point
+    def data_pipeline_runner(self):
+        self.download_files_from_kaggle()
+        for func in self.preprocessing_steps:
+            # If it's easier, function can be applied to column instead of row
+            self.skin_data = self.skin_data.apply(func, axis=1)
+            print('Finished applying {}'.format(func.__name__))


### PR DESCRIPTION
**Changes**
- added `DataPipeline` responsible for transforming the data
- added exception handling in case Kaggle data cannnot be downloaded
- added placeholder callables in lieu of actual preprocessing steps
- added csv files to `.gitignore`
- load environment variables in `data.py`

**Usage**
To instantiate the data pipeline when building the model:
```
pipeline = DataPipeline()
pipeline.data_pipeline_runner()
```